### PR TITLE
Compile sass in all directory

### DIFF
--- a/generators/app/templates/my-awesome-site/gulpfile.babel
+++ b/generators/app/templates/my-awesome-site/gulpfile.babel
@@ -74,17 +74,19 @@ gulp.task('css', () => {
 <% if (includeSass || includeScss) { -%>
 // Compile scss to css.
 gulp.task('scss', () => {
+//This will check for sass in all pages of the site, incase you use them
+//TODO: Move all Jekyll setup in a folder, build to another folder
 <% if (includeSass) { -%>
-    return gulp.src('sass/main.sass')
+    return gulp.src(['**/css/*.sass','!_site']])
 <% } -%>
 <% if (includeScss) { -%>
-    return gulp.src('scss/main.scss')
+    return gulp.src(['**/css/*.scss','!_site'])
 <% } -%>
         .pipe($.sass({
             includePaths: ['css'],
             onError: browserSync.notify
         }))
-        .pipe(gulp.dest('css'));
+        .pipe(gulp.dest('.'));
 });
 
 <% } -%>


### PR DESCRIPTION
You don't want to use one gigantic style sheet for every page on your site.
Gulp will output compiled css to the same folder as sass file, there no work around that I know of, so it best to just put sass in a folder named 'css'. If you really want to name the folder sass or scss, you have to update the html